### PR TITLE
Add power control of MPU9250: 3V - always ON

### DIFF
--- a/arch/arm/boot/dts/omap3-orion2016.dts
+++ b/arch/arm/boot/dts/omap3-orion2016.dts
@@ -140,6 +140,12 @@
 	regulator-max-microvolt = <2800000>;
 };
 
+&vaux4 {
+  regulator-min-microvolt = <3000000>;
+  regulator-max-microvolt = <3000000>;
+  regulator-always-on;
+};
+
 &dss {
 	status = "ok";
 };


### PR DESCRIPTION
Добавил управление питанием в dts для MPU9250